### PR TITLE
Remove strapp paparazzi fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "third-party/paparazzi"]
-	path = third-party/paparazzi
-	url = git@github.com:strapp-au/paparazzi.git


### PR DESCRIPTION
We don't need to include our fork of paparazzi anymore as Strapp is now working with the production version of paparazzi